### PR TITLE
Create abechat-server.yml

### DIFF
--- a/.github/workflows/abechat-server.yml
+++ b/.github/workflows/abechat-server.yml
@@ -34,4 +34,5 @@ jobs:
       uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
     - name: Build with Gradle Wrapper
-      run: ./AbeChatServer/gradlew build
+      working-directory: ./AbeChatServer
+      run: ./gradlew build


### PR DESCRIPTION
#1 
Set up CI to run a build of AbeChatServer. This should run a build of AbeChatServer any time main is pushed to directly (which shouldn't happen anymore hopefully), or if a PR is opened up against it.